### PR TITLE
Add a hash character in the first line of parameter txt files

### DIFF
--- a/SQLi-parameters.txt
+++ b/SQLi-parameters.txt
@@ -1,4 +1,4 @@
-Top 25 SQL Injection Parameters for @trbughunters
+# Top 25 SQL Injection Parameters for @trbughunters
 
 ?id=
 ?page=

--- a/lfi-parameters.txt
+++ b/lfi-parameters.txt
@@ -1,4 +1,4 @@
-Top 25 Local File Inclusion (LFI) Parameters for @trbughunters
+# Top 25 Local File Inclusion (LFI) Parameters for @trbughunters
 
 ?cat={payload}
 ?dir={payload}

--- a/openredirect-parameters.txt
+++ b/openredirect-parameters.txt
@@ -1,4 +1,4 @@
-Top 25 Open Redirect Parameters for @lutfumertceylan
+# Top 25 Open Redirect Parameters for @lutfumertceylan
 
 ?next={payload}
 ?url={payload}

--- a/rce-paramaters-get-based.txt
+++ b/rce-paramaters-get-based.txt
@@ -1,4 +1,4 @@
-Top 25 Remote Code Execution (RCE) Parameters [GET based] for @trbughunters
+# Top 25 Remote Code Execution (RCE) Parameters [GET based] for @trbughunters
 
 ?cmd=
 ?exec=

--- a/ssrf-parameters.txt
+++ b/ssrf-parameters.txt
@@ -1,4 +1,4 @@
-Top 25 Server-Side Request Forgery (SSRF) Parameters for @trbughunters
+# Top 25 Server-Side Request Forgery (SSRF) Parameters for @trbughunters
 
 ?dest={target}
 ?redirect={target}

--- a/xss-parameters.txt
+++ b/xss-parameters.txt
@@ -1,4 +1,4 @@
-Top 25 Cross-Site Scripting (XSS) Parameters for @trbughunters
+# Top 25 Cross-Site Scripting (XSS) Parameters for @trbughunters
 
 ?q={payload}
 ?s={payload}


### PR DESCRIPTION
Added a hash character which is a comment character in some languages.

# Why?

If a developer wants to load parameters in txt files, the developer can easily exclude the lines that start with a hash character.

For example, in Python, the developer can write something like this:

```py
with open("lfi-parameters.txt") as f:
    for line in f:
        line = line.strip()
        if line.startswith("#") or line == "":
            continue
        print(line)
```

Another solution is to exclude the first two lines, but I think it is better to use a comment character in txt files and exclude the lines that start with it.